### PR TITLE
Fix an awkwrd missing space after the dots

### DIFF
--- a/lib/todo_lint/cli.rb
+++ b/lib/todo_lint/cli.rb
@@ -38,6 +38,7 @@ module TodoLint
         end
       end.flatten.compact
       if reports.any?
+        puts
         reports.each do |report|
           puts report
         end


### PR DESCRIPTION
Before:

![screenshot 2015-07-11 16 39 36](https://cloud.githubusercontent.com/assets/1421211/8635305/7b04aa7c-27eb-11e5-9147-66aca8ede60a.png)

After:

![screenshot 2015-07-11 16 39 47](https://cloud.githubusercontent.com/assets/1421211/8635304/7af875cc-27eb-11e5-86c8-365045b3c377.png)

