### PR TITLE
make it rubocop compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Go through your TODO comments, and change from:
 to:
 
 ```ruby
-# TODO(2043-11-05): refactor into multiple classes
+# TODO: refactor into multiple classes (2043-11-05)
 ```
 
 Now your build will pass. Until November, 2043.

--- a/lib/todo_lint/todo.rb
+++ b/lib/todo_lint/todo.rb
@@ -6,8 +6,8 @@ module TodoLint
     (?<flag> TODO ){0}
     (?<due_date> \(\d{4}-\d{2}-\d{2}\)){0}
     (?<tag>\#\w+){0}
-    (?<task>.+){0}
-    \g<flag>(?:\g<due_date>|(?:\(\g<tag>\)))?: \g<task>
+    (?<task>.+?){0}
+    \g<flag>: \g<task>(?:\g<due_date>|(?:\(\g<tag>\)))?
     /x
 
     # Search a file for all of the todo/fixme/etc comments within it

--- a/spec/todo_lint/reporter_spec.rb
+++ b/spec/todo_lint/reporter_spec.rb
@@ -25,7 +25,7 @@ module TodoLint
       end
 
       it "does not report on a todo with a silent judge" do
-        todo = Todo.new("  # TODO(1994-05-11): follow your heart",
+        todo = Todo.new("  # TODO: follow your heart (1994-05-11)",
                         :line_number => 45,
                         :path => path,
                         :config => {})

--- a/spec/todo_lint/todo_spec.rb
+++ b/spec/todo_lint/todo_spec.rb
@@ -71,7 +71,7 @@ module TodoLint
     describe "#annotated?, #flag, #due_date" do
       context "when the line is annotated with a due date" do
         it "should return true" do
-          todo = todo_with_line("# TODO(2015-08-29): solve a crime")
+          todo = todo_with_line("# TODO: solve a crime (2015-08-29)")
           expect(todo).to be_annotated
           expect(todo.flag).to eq "TODO"
           expect(todo.due_date).to be_a DueDate
@@ -82,7 +82,7 @@ module TodoLint
       context "when the line is annotated with a tag" do
         context "and the config is aware of the tag" do
           it "should return true" do
-            todo = todo_with_line("# TODO(#omg): solve a crime")
+            todo = todo_with_line("# TODO: solve a crime (#omg)")
             expect(todo).to be_annotated
             expect(todo.flag).to eq "TODO"
             expect(todo.due_date).to be_a DueDate
@@ -92,7 +92,7 @@ module TodoLint
 
         context "and the config is *not* aware of the tag" do
           it "should raise an error" do
-            todo = todo_with_line("# TODO(#shipit): solve a crime")
+            todo = todo_with_line("# TODO: solve a crime (#shipit)")
             expect { todo.due_date }.to raise_error(
               KeyError, "#shipit tag not defined in config file"
             )
@@ -122,8 +122,8 @@ module TodoLint
       context "when all of the todos have due dates" do
         it "sorts them with newer todos first" do
           todos = [
-            todo_with_line("# TODO(1969-04-04): commit a crime"),
-            todo_with_line("# TODO(1955-08-02): plan a crime")
+            todo_with_line("# TODO: commit a crime (1969-04-04)"),
+            todo_with_line("# TODO: plan a crime (1955-08-02)")
           ]
 
           expect(todos.sort.map(&:task)).to eq [
@@ -136,9 +136,9 @@ module TodoLint
       context "when some of the todos don't have due dates" do
         it "sorts the unannotated ones to the front" do
           todos = [
-            todo_with_line("# TODO(1969-04-04): commit a crime"),
+            todo_with_line("# TODO: commit a crime (1969-04-04)"),
             todo_with_line("# TODO: buy some spray paint"),
-            todo_with_line("# TODO(1955-08-02): plan a crime")
+            todo_with_line("# TODO: plan a crime (1955-08-02)")
           ]
 
           expect(todos.sort.map(&:task)).to eq [


### PR DESCRIPTION
noticed, too late, that if you write a TODO in a way that makes todo_lint happy, it makes rubocop unhappy. I thought I'd move the annotation to the end of the line, but it's a kind of tricky regex to write...

this will have to be a breaking change, so it'll become a 2.0 release once it works